### PR TITLE
feat: closing viewer mdi windows

### DIFF
--- a/glue_solara/hooks.py
+++ b/glue_solara/hooks.py
@@ -1,5 +1,6 @@
 import glue.core.hub
 import glue.core.message
+import glue_jupyter
 import solara
 from glue.viewers.common.viewer import Viewer
 
@@ -9,14 +10,20 @@ class DummyListener(glue.core.hub.HubListener):
         pass
 
 
+# Message indicating a viewer should be closed
+class ClosedMessage(glue.core.message.Message):
+    def __init__(self, sender):
+        super().__init__(sender=sender)
+
+
 helper = []
 
 
-def use_glue_watch(hub: glue.core.hub.Hub, msg_class=glue.core.message.Message):
+def use_glue_watch(hub: glue.core.hub.Hub, msg_class=glue.core.message.Message, on_msg=None):
     # listener = solara.use_memo(lambda: DummyListener(), [])
     counter, set_counter = solara.use_state(0)
 
-    def on_msg(msg):
+    def _on_msg(msg):
         # breakpoint()
         # print("MSG", msg, counter)
         set_counter(lambda counter: counter + 1)
@@ -25,12 +32,28 @@ def use_glue_watch(hub: glue.core.hub.Hub, msg_class=glue.core.message.Message):
         listener = DummyListener()
         helper.append(listener)
         # breakpoint()
-        hub.subscribe(listener, msg_class, handler=on_msg)
+        hub.subscribe(listener, msg_class, handler=on_msg or _on_msg)
         assert listener in hub._subscriptions
         # def clean
         # return lambda: hub.unsubscribe(listener, msg_class)
 
     solara.use_effect(connect, [id(hub)])
+
+
+def use_glue_watch_close(app: glue_jupyter.JupyterApplication):
+    counter, set_counter = solara.use_state(0)
+
+    def remove_viewer(msg):
+        viewers = app._viewer_refs
+        for _viewer in viewers:
+            viewer = _viewer()
+            if viewer is not None and viewer is msg.sender:
+                # TODO: a proper close method should be implemented in glue-jupyter
+                viewer.cleanup()
+                viewers.remove(_viewer)
+        set_counter(lambda counter: counter + 1)
+
+    use_glue_watch(app.session.hub, ClosedMessage, remove_viewer)
 
 
 def use_layers_watch(viewers: list[Viewer]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "glue-solara"
 description = "Flexible Solara based Glue UI"
 version = "0.0.1"
 dependencies = [
-    "solara",
+    "solara>=1.40.0",
     "glue-jupyter",
     "ipypopout",
 ]


### PR DESCRIPTION
Let's you close viewers through the mdi window close button. Closing should still be properly implemented in glue-jupyter.