### PR TITLE
Get initial state for viewers from app

### DIFF
--- a/glue_solara/app.py
+++ b/glue_solara/app.py
@@ -164,7 +164,7 @@ def GlueApp(app: gj.JupyterApplication):
     use_glue_watch(app.session.hub, msg.DataCollectionMessage)
     use_glue_watch_close(app)
     data_collection = app.data_collection
-    viewer_index: Reactive[Optional[int]] = solara.use_reactive(None)
+    viewer_index: Reactive[Optional[int]] = solara.use_reactive(0 if app.viewers else None)
     show_error = solara.use_reactive(False)
     error_message = solara.use_reactive("")
 
@@ -172,8 +172,16 @@ def GlueApp(app: gj.JupyterApplication):
     requested_viewer_typename = solara.use_reactive("Scatter")
 
     view_type = solara.use_reactive("tabs")  # tabs, grid, mdi
-    mdi_layouts: Reactive[List[MdiWindow]] = solara.use_reactive([])
-    grid_layout: Reactive[List[Dict]] = solara.use_reactive([])
+
+    # Initialize layouts from any pre-existing viewers (e.g. from a restored session)
+    initial_grid = [{"h": 18, "i": str(i), "moved": False, "w": 12, "x": 0, "y": 12 * i}
+                    for i in range(len(app.viewers))]
+    initial_mdi = [{"title": TITLE_TRANSLATIONS.get(v.__class__.__name__, v.__class__.__name__),
+                    "width": 800, "height": 600}
+                   for v in app.viewers]
+
+    mdi_layouts: Reactive[List[MdiWindow]] = solara.use_reactive(initial_mdi)
+    grid_layout: Reactive[List[Dict]] = solara.use_reactive(initial_grid)
     mdi_header_size_index = solara.use_reactive(2)
 
     def add_data_viewer(type: str, data: glue.core.Data):

--- a/tests/unit/app_test.py
+++ b/tests/unit/app_test.py
@@ -1,0 +1,37 @@
+import solara
+from glue.core import Data
+from glue_jupyter.app import JupyterApplication
+
+from glue_solara.app import GlueApp
+
+
+def _create_app_with_viewers():
+    app = JupyterApplication()
+    data = Data(x=[1, 2, 3], y=[4, 5, 6], label='test')
+    app.data_collection.append(data)
+    app.scatter2d(data=data, show=False)
+    app.histogram1d(data=data, show=False)
+    return app
+
+
+def test_glue_app_with_existing_viewers():
+    app = _create_app_with_viewers()
+    assert len(app.viewers) == 2
+
+    @solara.component
+    def TestComponent():
+        GlueApp(app)
+
+    box, rc = solara.render(TestComponent(), handle_error=False)
+    box.close()
+
+
+def test_glue_app_with_no_viewers():
+    app = JupyterApplication()
+
+    @solara.component
+    def TestComponent():
+        GlueApp(app)
+
+    box, rc = solara.render(TestComponent(), handle_error=False)
+    box.close()


### PR DESCRIPTION
I am doing some experiments with loading session files into glue-solara, which means that the initial app object may have viewers already defined. This change makes it so that if viewers exist on the app, they are used as initial existing viewers.